### PR TITLE
회원가입 기능 구현 성공

### DIFF
--- a/OrderService/src/main/java/com/example/orderservice/controller/UserController.java
+++ b/OrderService/src/main/java/com/example/orderservice/controller/UserController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 
 @RestController
-@RequestMapping("/register")
+//@RequestMapping("/register")
 public class UserController {
     private final UserService userService;
 
@@ -15,8 +15,10 @@ public class UserController {
         this.userService = userService;
     }
 
-    @PostMapping
+    @PostMapping("/register")
     public RedirectView registerUser(@ModelAttribute UserDto userDto) {
+        System.out.println(userDto.id());
+        System.out.println(userDto.name());
         UserDto addedUser = userService.addUser(userDto);
         return new RedirectView("/menu");
     }

--- a/OrderService/src/main/java/com/example/orderservice/dto/UserDto.java
+++ b/OrderService/src/main/java/com/example/orderservice/dto/UserDto.java
@@ -2,7 +2,7 @@ package com.example.orderservice.dto;
 
 import com.example.orderservice.entity.User;
 
-public record UserDto(int id, String name) {
+public record UserDto(Integer id, String name) {
     public static UserDto fromEntity(User user) {
         return new UserDto(
                 user.getId(),

--- a/OrderService/src/main/java/com/example/orderservice/entity/User.java
+++ b/OrderService/src/main/java/com/example/orderservice/entity/User.java
@@ -8,7 +8,7 @@ import java.util.List;
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Integer id;
     private String name;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)

--- a/dbStructure.sql
+++ b/dbStructure.sql
@@ -13,7 +13,7 @@ CREATE TABLE menu (
     price INT
 );
 
-CREATE TABLE `order` (
+CREATE TABLE orders (
     id INT PRIMARY KEY AUTO_INCREMENT, -- 고유 식별자 추가
     user_id INT REFERENCES user(id) ON DELETE CASCADE,
     menu_id INT REFERENCES menu(id) ON DELETE CASCADE,


### PR DESCRIPTION
## 주요 사항

- `AUTO_INCREMENT`가 MySQL 테이블 정의에서도 있어야 함.
  단순히 자바에서 `GeneratedValue(strategy = GenerationType.IDENTITY)` 로 정의했다고
  자동으로 증가하는 ID가 생성되지 않음.